### PR TITLE
Allows overwriting of environment variables

### DIFF
--- a/src/LittleForker.Tests/ProcessSupervisorTests.cs
+++ b/src/LittleForker.Tests/ProcessSupervisorTests.cs
@@ -112,7 +112,7 @@ namespace LittleForker
         [Fact]
         public async Task Can_restart_a_stopped_long_running_process()
         {
-            var supervisor = new ProcessSupervisor(ProcessRunType.NonTerminating, Environment.CurrentDirectory, "dotnet", "./LongRunningProcess/LongRunningProcess.dll");
+            var supervisor = new ProcessSupervisor(ProcessRunType.NonTerminating, Environment.CurrentDirectory, "dotnet", "./NonTerminatingProcess/NonTerminatingProcess.dll");
             supervisor.OutputDataReceived += data => _outputHelper.WriteLine2(data);
             var stateIsStopped = supervisor.WhenStateIs(ProcessSupervisor.State.ExitedSuccessfully);
             supervisor.Start();
@@ -129,7 +129,7 @@ namespace LittleForker
         [Fact]
         public async Task When_stop_a_non_terminating_process_then_should_exit_successfully()
         {
-            var supervisor = new ProcessSupervisor(ProcessRunType.NonTerminating, Environment.CurrentDirectory, "dotnet", "./LongRunningProcess/LongRunningProcess.dll");
+            var supervisor = new ProcessSupervisor(ProcessRunType.NonTerminating, Environment.CurrentDirectory, "dotnet", "./NonTerminatingProcess/NonTerminatingProcess.dll");
             supervisor.OutputDataReceived += data => _outputHelper.WriteLine2(data);
             var stateIsStopped = supervisor.WhenStateIs(ProcessSupervisor.State.ExitedSuccessfully);
             supervisor.Start();

--- a/src/LittleForker/LittleForker.csproj
+++ b/src/LittleForker/LittleForker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.3"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
+    <!--<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>-->
     <PackageReference Include="MinVer" Version="1.0.0-rc.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/LittleForker/ProcessSupervisor.cs
+++ b/src/LittleForker/ProcessSupervisor.cs
@@ -229,7 +229,7 @@ namespace LittleForker
                 {
                     foreach (string key in _environmentVariables.Keys)
                     {
-                        processStartInfo.EnvironmentVariables.Add(key, _environmentVariables[key]);
+                        processStartInfo.EnvironmentVariables[key] = _environmentVariables[key];
                     }
                 }
 


### PR DESCRIPTION
Environment variables cannot be overwritten if they already exist, because the system tries to add them.

This change overwrites the environment variable. 