### PR TITLE
Replace TRAVIS_BUILD_NUMBER with just BUILD_NUMBER

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,12 +5,12 @@
     <PackageProjectUrl>https://github.com/damianh/LittleForker</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/damianh/LittleForker/blob/master/LICENSE</PackageLicenseUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageTags>child-process;process-manager</PackageTags>
+    <PackageTags>child-process;process-manager;process-supervision</PackageTags>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <LangVersion>latest</LangVersion>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerMinimumMajorMinor>0.1</MinVerMinimumMajorMinor>
-    <TRAVIS_BUILD_NUMBER Condition="'$(TRAVIS_BUILD_NUMBER)' == ''">0</TRAVIS_BUILD_NUMBER>
-    <MinVerBuildMetadata>build.$(TRAVIS_BUILD_NUMBER)</MinVerBuildMetadata>
+    <BUILD_NUMBER Condition="'$(BUILD_NUMBER)' == ''">0</BUILD_NUMBER>
+    <MinVerBuildMetadata>build.$(BUILD_NUMBER)</MinVerBuildMetadata>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Otherwise packages won't have correct build numbers