### PR TITLE
Log a warning of the timeout before killing the process

### DIFF
--- a/src/LittleForker/ProcessSupervisor.cs
+++ b/src/LittleForker/ProcessSupervisor.cs
@@ -327,6 +327,10 @@ namespace LittleForker
                     // time.
                     try
                     {
+                        _logger.LogWarning(
+                            $"Timed out waiting to signal the process to exit or the " +
+                            $"process {_process.ProcessName} ({_process.Id}) did not shutdown in " +
+                            $"the given time ({timeout})");
                         _process.Kill();
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Due to the current version of `LittleForker` not exposing a `ExitKilled` state (see: https://github.com/damianh/LittleForker/pull/96), we want to at least make visible through a log that `LittleForker` killed the process after the given timeout expired (either failing to signal the process to exit in time or the process failed to shutdown in the given time).