### PR TITLE
Stop waiting on ExitedWithError

### DIFF
--- a/src/LittleForker/ProcessSupervisor.cs
+++ b/src/LittleForker/ProcessSupervisor.cs
@@ -312,12 +312,7 @@ namespace LittleForker
                     // only means the process has _started_ to shut down.
 
                     await CooperativeShutdown.SignalExit(ProcessInfo.Id, _loggerFactory).TimeoutAfter(timeout.Value);
-                    var exited = this.WhenStateIs(State.ExitedSuccessfully);
-                    var exitedWithError = this.WhenStateIs(State.ExitedWithError);
-
-                    await Task
-                        .WhenAny(exited, exitedWithError)
-                        .TimeoutAfter(timeout.Value);
+                    await this.WhenStateIs(State.ExitedSuccessfully).TimeoutAfter(timeout.Value);
                 }
                 catch (TimeoutException)
                 {


### PR DESCRIPTION
The state machine is only configured to be able to transition to the `ExitedSuccessfully` state from the `Stopping` state when the `ProcessExit` trigger is triggered which means that there is no benefit to doing so.